### PR TITLE
Implements home row modifiers

### DIFF
--- a/config/corneish_zen.keymap
+++ b/config/corneish_zen.keymap
@@ -5,8 +5,8 @@
 *
 */
 
-// #define LHYP LS(LC(LA(LCMD)))
-// #define RHYP RS(RC(RA(RCMD)))
+#define LHYP LS(LC(LA(LCMD)))
+#define RHYP RS(RC(RA(RCMD)))
 
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/keys.h>
@@ -45,7 +45,7 @@
             //             | ESC | SPC | TAB |                 | ENT | BKSP | DEL |
             bindings = <
                 &kp Q       &kp W      &kp F      &kp P       &kp B                       &kp J      &kp L       &kp U      &kp Y      &kp SQT
-                &hm LCTRL A &hm LALT R &hm LCMD S &hm LSHFT T &hm LS(LC(LA(LCMD))) G      &hm RS(RC(RA(RCMD))) M &hm RSHFT N &hm RCMD E &hm RALT I &hm RCTRL O
+                &hm LCTRL A &hm LALT R &hm LCMD S &hm LSHFT T &hm LHYP G                  &hm RHYP M &hm RSHFT N &hm RCMD E &hm RALT I &hm RCTRL O
                 &kp Z       &kp X      &kp C      &kp D       &kp V                       &kp K      &kp H       &kp COMMA  &kp DOT    &kp FSLH
                                        &kp ESC    &lt 1 SPACE &lt 1 TAB                   &lt 1 RET  &lt 1 BSPC  &lt 1 DEL
             >;

--- a/config/corneish_zen.keymap
+++ b/config/corneish_zen.keymap
@@ -5,8 +5,8 @@
 *
 */
 
-#define LHYP LS(LC(LA(LCMD)))
-#define RHYP RS(RC(RA(RCMD)))
+// #define LHYP LS(LC(LA(LCMD)))
+// #define RHYP RS(RC(RA(RCMD)))
 
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/keys.h>
@@ -44,10 +44,10 @@
             // |  Z  |  X  |  C  |  D  |  V  |                 |  K  |  H   |  ,  |  .  |  /  |
             //             | ESC | SPC | TAB |                 | ENT | BKSP | DEL |
             bindings = <
-                &kp Q       &kp W      &kp F      &kp P       &kp B            &kp J      &kp L       &kp U      &kp Y      &kp SQT
-                &hm LCTRL A &hm LALT R &hm LCMD S &hm LSHFT T &hm LHYP G       &hm RHYP M &hm LSHFT N &hm RCMD E &hm RALT I &hm RCTRL O
-                &kp Z       &kp X      &kp C      &kp D       &kp V            &kp K      &kp H       &kp COMMA  &kp DOT    &kp FSLH
-                                       &kp ESC    &lt 1 SPACE &lt 1 TAB        &lt 1 RET  &lt 1 BSPC  &lt 1 DEL
+                &kp Q       &kp W      &kp F      &kp P       &kp B                       &kp J      &kp L       &kp U      &kp Y      &kp SQT
+                &hm LCTRL A &hm LALT R &hm LCMD S &hm LSHFT T &hm LS(LC(LA(LCMD))) G      &hm RS(RC(RA(RCMD))) M &hm RSHFT N &hm RCMD E &hm RALT I &hm RCTRL O
+                &kp Z       &kp X      &kp C      &kp D       &kp V                       &kp K      &kp H       &kp COMMA  &kp DOT    &kp FSLH
+                                       &kp ESC    &lt 1 SPACE &lt 1 TAB                   &lt 1 RET  &lt 1 BSPC  &lt 1 DEL
             >;
         };
 

--- a/config/corneish_zen.keymap
+++ b/config/corneish_zen.keymap
@@ -5,6 +5,9 @@
 *
 */
 
+#define LHYP LS(LC(LA(LCMD)))
+#define RHYP RS(RC(RA(RCMD)))
+
 #include <behaviors.dtsi>
 #include <dt-bindings/zmk/keys.h>
 #include <dt-bindings/zmk/bt.h>
@@ -13,6 +16,19 @@
     chosen {
         // zmk,matrix-transform = &default_transform;
         zmk,matrix-transform = &five_column_transform;
+    };
+};
+
+/ {
+    behaviors {
+        hm: homerow_mods {
+            compatible = "zmk,behavior-hold-tap";
+            #binding-cells = <2>;
+            tapping-term-ms = <150>;
+            quick-tap-ms = <0>;
+            flavor = "tap-preferred";
+            bindings = <&kp>, <&kp>;
+        };
     };
 };
 
@@ -28,10 +44,10 @@
             // |  Z  |  X  |  C  |  D  |  V  |                 |  K  |  H   |  ,  |  .  |  /  |
             //             | ESC | SPC | TAB |                 | ENT | BKSP | DEL |
             bindings = <
-                &kp Q &kp W &kp F   &kp P       &kp B            &kp J     &kp L      &kp U     &kp Y   &kp SQT
-                &kp A &kp R &kp S   &kp T       &kp G            &kp M     &kp N      &kp E     &kp I   &kp O
-                &kp Z &kp X &kp C   &kp D       &kp V            &kp K     &kp H      &kp COMMA &kp DOT &kp FSLH
-                            &kp ESC &lt 1 SPACE &lt 1 TAB        &lt 1 RET &lt 1 BSPC &lt 1 DEL
+                &kp Q       &kp W      &kp F      &kp P       &kp B            &kp J      &kp L       &kp U      &kp Y      &kp SQT
+                &hm LCTRL A &hm LALT R &hm LCMD S &hm LSHFT T &hm LHYP G       &hm RHYP M &hm LSHFT N &hm RCMD E &hm RALT I &hm RCTRL O
+                &kp Z       &kp X      &kp C      &kp D       &kp V            &kp K      &kp H       &kp COMMA  &kp DOT    &kp FSLH
+                                       &kp ESC    &lt 1 SPACE &lt 1 TAB        &lt 1 RET  &lt 1 BSPC  &lt 1 DEL
             >;
         };
 


### PR DESCRIPTION
Implements home row modifiers:
- holding activates a modifier (shift, ctrl, opt, command, hyper)
- tap outputs a keycode
- pinkies = control
- rings = option
- middle = command
- pointer = shift
- pointer 2 = hyper

Tuning:
- taps are defined as key press < 150 ms
- double-tap-and-hold outputs the same key codes as tapping really fast over and over
- i picked the `tap-preferred` flavor because it handles key rollovers the way you expect