### PR TITLE
Implements Hands Down Gold layout (with modifications)

### DIFF
--- a/config/corneish_zen.keymap
+++ b/config/corneish_zen.keymap
@@ -38,16 +38,16 @@
 
         default_layer {
             display-name = "ALPHA";
-            // --------------------------------------------------------------------------------
-            // |  Q  |  W  |  F  |  P  |  B  |                                 |  J  |  L   |  U  |  Y  |  '  |
-            // |  A  |  R  |  S  |  T  |  G  |                                 |  M  |  N   |  E  |  I  |  O  |
-            // |  Z  |  X  |  C  |  D  |  V  |                                 |  K  |  H   |  ,  |  .  |  /  |
-            //             | ESC | SPC | TAB |                                 | ENT | BKSP | DEL |
+            // ------------------------------------------------------------------------------------------------
+            // |  J  |  G  |  M  |  P   |  V  |                                 |  /  |  .  |  Q  |  '  |  -  |
+            // |  R  |  S  |  N  |  D   |  B  |                                 |  ,  |  A  |  E  |  I  |  H  |
+            // |  X  |  F  |  L  |  C   |  W  |                                 |  Z  |  U  |  O  |  Y  |  K  |
+            //             | ESC | BKSP |  T  |                                 | SPC | ENT | TAB |
             bindings = <
-                &kp Q       &kp W      &kp F      &kp P       &kp B             &kp J      &kp L       &kp U      &kp Y      &kp SQT
-                &hm LCTRL A &hm LALT R &hm LCMD S &hm LSHFT T &hm LHYP G        &hm RHYP M &hm RSHFT N &hm RCMD E &hm RALT I &hm RCTRL O
-                &kp Z       &kp X      &kp C      &kp D       &kp V             &kp K      &kp H       &kp COMMA  &kp DOT    &kp FSLH
-                                       &kp ESC    &lt 3 SPACE &lt 4 TAB         &lt 2 RET  &lt 1 BSPC  &lt 5 DEL
+                &kp J       &kp G      &kp M      &kp P       &kp V             &kp FSLH       &kp DOT     &kp Q      &kp SQT    &kp MINUS
+                &hm LCTRL R &hm LALT S &hm LCMD N &hm LSHFT D &hm LHYP B        &hm RHYP COMMA &hm RSHFT A &hm RCMD E &hm RALT I &hm RCTRL H
+                &kp X       &kp F      &kp L      &kp C       &kp W             &kp Z          &kp U       &kp O      &kp Y      &kp K
+                                       &kp ESC    &lt 3 BSPC  &lt 4 T           &lt 2 SPACE    &lt 1 RET   &lt 5 TAB
             >;
         };
 
@@ -114,15 +114,15 @@
          fn_layer {
             display-name = "FN";
             // -------------------------------------------------------------------------
-            // | F12 | F7 | F8 | F9 |    |             |     |      |     |     |      |
-            // | F11 | F4 | F5 | F6 |    |             | HYP | SHFT | CMD | OPT | CTRL |
-            // | F10 | F1 | F2 | F3 |    |             |     |      |     |     |      |
-            //            |    |    |    |             |     |      | ALPHA |
+            // | F12 | F7 | F8 | F9 |    |              |     |      |     |     |      |
+            // | F11 | F4 | F5 | F6 |    |              | HYP | SHFT | CMD | OPT | CTRL |
+            // | F10 | F1 | F2 | F3 |    |              |     |      |     |     |      |
+            //            |    |    |    |              |     |      | ALPHA |
             bindings = <
-                &kp F12 &kp F7 &kp F8 &kp F9 &none      &none    &none     &none    &none    &none
-                &kp F11 &kp F4 &kp F5 &kp F6 &none      &kp RHYP &kp RSHFT &kp RCMD &kp RALT &kp RCTRL
-                &kp F10 &kp F1 &kp F2 &kp F3 &none      &none    &none     &none    &none    &none
-                               &none  &none  &none      &none    &none     &to 0
+                &kp F12 &kp F7 &kp F8 &kp F9  &none      &none    &none     &none    &none    &none
+                &kp F11 &kp F4 &kp F5 &kp F6  &none      &kp RHYP &kp RSHFT &kp RCMD &kp RALT &kp RCTRL
+                &kp F10 &kp F1 &kp F2 &kp F3  &none      &none    &none     &none    &none    &none
+                               &none  &kp DEL &none      &none    &none     &to 0
             >;
         };
     };

--- a/config/corneish_zen.keymap
+++ b/config/corneish_zen.keymap
@@ -39,14 +39,14 @@
         default_layer {
             display-name = "ALPHA";
             // ------------------------------------------------------------------------------------------------
-            // |  J  |  G  |  M  |  P   |  V  |                                 |  /  |  .  |  Q  |  '  |  -  |
-            // |  R  |  S  |  N  |  D   |  B  |                                 |  ,  |  A  |  E  |  I  |  H  |
             // |  X  |  F  |  L  |  C   |  W  |                                 |  Z  |  U  |  O  |  Y  |  K  |
+            // |  R  |  S  |  N  |  D   |  B  |                                 |  ,  |  A  |  E  |  I  |  H  |
+            // |  J  |  G  |  M  |  P   |  V  |                                 |  /  |  .  |  Q  |  '  |  -  |
             //             | ESC | BKSP |  T  |                                 | SPC | ENT | TAB |
             bindings = <
-                &kp J       &kp G      &kp M      &kp P       &kp V             &kp FSLH       &kp DOT     &kp Q      &kp SQT    &kp MINUS
-                &hm LCTRL R &hm LALT S &hm LCMD N &hm LSHFT D &hm LHYP B        &hm RHYP COMMA &hm RSHFT A &hm RCMD E &hm RALT I &hm RCTRL H
                 &kp X       &kp F      &kp L      &kp C       &kp W             &kp Z          &kp U       &kp O      &kp Y      &kp K
+                &hm LCTRL R &hm LALT S &hm LCMD N &hm LSHFT D &hm LHYP B        &hm RHYP COMMA &hm RSHFT A &hm RCMD E &hm RALT I &hm RCTRL H
+                &kp J       &kp G      &kp M      &kp P       &kp V             &kp FSLH       &kp DOT     &kp Q      &kp SQT    &kp MINUS
                                        &kp ESC    &lt 3 BSPC  &lt 4 T           &lt 2 SPACE    &lt 1 RET   &lt 5 TAB
             >;
         };


### PR DESCRIPTION
Implements a modified version of [Hands Down Gold](https://sites.google.com/alanreiser.com/handsdown#h.j66p50cw2471):
* Keeps the left hand layout, but omits combos to output z (`j` + `g`) and q (`g` + `p`)
* Uses the right hand alphabetic layout (of Gold) + relocates `z` to the bottom row inner col + relocates `q` to top row middle finger
* Uses the right hand's symbol layout of Hands Down Neu, but recombines `'` and `"` back into one key, and relocates `-` to top row pinky finger
* Added `backspace` and `escape` to left thumb cluster
    * Added combo so `fn` + `backspace` outputs (forward) `delete`
* Added `enter` and `tab` to right thumb cluster

After some experience with the above layout, I further modified Hands Down to:
* Swap the bottom and top row of letters (finger extension is more comfortable than flexion)